### PR TITLE
migrating from canvas-prebuilt which was deprecated to canvas 2.6.1 and refactoring code

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ OS X | `brew install pkg-config cairo pango libpng jpeg giflib`
 Ubuntu | `sudo apt-get install libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++`
 Fedora | `sudo yum install cairo cairo-devel cairomm-devel libjpeg-turbo-devel pango pango-devel pangomm pangomm-devel giflib-devel`
 Solaris | `pkgin install cairo pango pkg-config xproto renderproto kbproto xextproto`
-Windows | [Instructions on our wiki](https://github.com/Automattic/node-canvas/wiki/Installation---Windows)
+Windows | npm i or npm install (canvas will be installed automatically)
 
 ```
 npm install node-echarts

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ OS X | `brew install pkg-config cairo pango libpng jpeg giflib`
 Ubuntu | `sudo apt-get install libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++`
 Fedora | `sudo yum install cairo cairo-devel cairomm-devel libjpeg-turbo-devel pango pango-devel pangomm pangomm-devel giflib-devel`
 Solaris | `pkgin install cairo pango pkg-config xproto renderproto kbproto xextproto`
-Windows | npm i or npm install (canvas will be installed automatically)
+Windows | `npm i` or `npm install` (canvas will be installed automatically)
 
 ```
 npm install node-echarts

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/suxiaoxin/node-echarts#readme",
   "dependencies": {
-    "canvas-prebuilt": "^1.6.5-prerelease.1",
+    "canvas": "^2.6.1",
     "echarts": "^4.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi. Thanks for you guys contribution, I did use this library for the first time today but I had a bad time to make it work in windows. 

So, in this PR I did migrate from canvas-prebuilt (which is deprecated) to canvas 2.6.1. And I did a bit refactoring in the code to improve the maintainability. Just separated a few "procedures" in separated functions, removed some duplicated code and added more docs. Hope it helps.

Ty